### PR TITLE
Replace PackageLicenseFile with PackageLicenseExpression

### DIFF
--- a/ProgressStream/ProgressStream.csproj
+++ b/ProgressStream/ProgressStream.csproj
@@ -17,14 +17,13 @@
         <LangVersion>8.0</LangVersion>
         <ImplicitUsings>disable</ImplicitUsings>
         <PackageReadmeFile>README.md</PackageReadmeFile>
-        <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <Version>1.1.0</Version>
         <PackageIcon>Simpleicons-Team-Simple-Progress.256.png</PackageIcon>
     </PropertyGroup>
 
     <ItemGroup>
         <None Include="..\README.md" Pack="true" PackagePath="\" />
-        <None Include="..\LICENSE.md" Pack="true" PackagePath="\" />
         <None Include="docs\Simpleicons-Team-Simple-Progress.256.png" Pack="true" PackagePath="\" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
According to [best practices](https://learn.microsoft.com/en-us/nuget/reference/msbuild-targets#packing-a-license-expression-or-a-license-file), when specifying licenses, it is recommended to use only specific terms if they are standard licenses.

`PackageLicenseFile` is usually used for custom licenses, but I see that's not the case here, it's `MIT`.